### PR TITLE
Socket/listen backlog default arg

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -911,9 +911,14 @@ STATIC mp_obj_t lwip_socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(lwip_socket_bind_obj, lwip_socket_bind);
 
-STATIC mp_obj_t lwip_socket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
-    lwip_socket_obj_t *socket = MP_OBJ_TO_PTR(self_in);
-    mp_int_t backlog = mp_obj_get_int(backlog_in);
+STATIC mp_obj_t lwip_socket_listen(size_t n_args, const mp_obj_t *args) {
+    lwip_socket_obj_t *socket = MP_OBJ_TO_PTR(args[0]);
+
+    mp_int_t backlog = 2;
+    if (n_args > 1) {
+        backlog = mp_obj_get_int(args[1]);
+        backlog = (backlog < 0) ? 0 : backlog;
+    }
 
     if (socket->pcb.tcp == NULL) {
         mp_raise_OSError(MP_EBADF);
@@ -946,7 +951,7 @@ STATIC mp_obj_t lwip_socket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(lwip_socket_listen_obj, lwip_socket_listen);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(lwip_socket_listen_obj, 1, 2, lwip_socket_listen);
 
 STATIC mp_obj_t lwip_socket_accept(mp_obj_t self_in) {
     lwip_socket_obj_t *socket = MP_OBJ_TO_PTR(self_in);

--- a/extmod/modusocket.c
+++ b/extmod/modusocket.c
@@ -116,9 +116,9 @@ STATIC mp_obj_t socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
 
-// method socket.listen(backlog)
-STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog) {
-    mod_network_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
+// method socket.listen([backlog])
+STATIC mp_obj_t socket_listen(size_t n_args, const mp_obj_t *args) {
+    mod_network_socket_obj_t *self = MP_OBJ_TO_PTR(args[0]);
 
     if (self->nic == MP_OBJ_NULL) {
         // not connected
@@ -126,14 +126,20 @@ STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog) {
         mp_raise_OSError(MP_ENOTCONN);
     }
 
+    mp_int_t backlog = 2;
+    if (n_args > 1) {
+        backlog = mp_obj_get_int(args[1]);
+        backlog = (backlog < 0) ? 0 : backlog;
+    }
+
     int _errno;
-    if (self->nic_type->listen(self, mp_obj_get_int(backlog), &_errno) != 0) {
+    if (self->nic_type->listen(self, backlog, &_errno) != 0) {
         mp_raise_OSError(_errno);
     }
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_listen_obj, socket_listen);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_listen_obj, 1, 2, socket_listen);
 
 // method socket.accept()
 STATIC mp_obj_t socket_accept(mp_obj_t self_in) {

--- a/ports/cc3200/mods/modusocket.c
+++ b/ports/cc3200/mods/modusocket.c
@@ -489,7 +489,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
 STATIC mp_obj_t socket_listen(size_t n_args, const mp_obj_t *args) {
     mod_network_socket_obj_t *self = args[0];
 
-    int32_t backlog = 0;
+    int32_t backlog = 2;
     if (n_args > 1) {
         backlog = mp_obj_get_int(args[1]);
         backlog = (backlog < 0) ? 0 : backlog;

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -295,9 +295,16 @@ STATIC mp_obj_t socket_bind(const mp_obj_t arg0, const mp_obj_t arg1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
 
-STATIC mp_obj_t socket_listen(const mp_obj_t arg0, const mp_obj_t arg1) {
-    socket_obj_t *self = MP_OBJ_TO_PTR(arg0);
-    int backlog = mp_obj_get_int(arg1);
+// method socket.listen([backlog])
+STATIC mp_obj_t socket_listen(size_t n_args, const mp_obj_t *args) {
+    socket_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    int backlog = 2;
+    if (n_args > 1) {
+        backlog = mp_obj_get_int(args[1]);
+        backlog = (backlog < 0) ? 0 : backlog;
+    }
+
     self->state = SOCKET_STATE_CONNECTED;
     int r = lwip_listen(self->fd, backlog);
     if (r < 0) {
@@ -305,7 +312,7 @@ STATIC mp_obj_t socket_listen(const mp_obj_t arg0, const mp_obj_t arg1) {
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_listen_obj, socket_listen);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_listen_obj, 1, 2, socket_listen);
 
 STATIC mp_obj_t socket_accept(const mp_obj_t arg0) {
     socket_obj_t *self = MP_OBJ_TO_PTR(arg0);

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -223,15 +223,23 @@ STATIC mp_obj_t socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
 
-STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
-    mp_obj_socket_t *self = MP_OBJ_TO_PTR(self_in);
+// method socket.listen([backlog])
+STATIC mp_obj_t socket_listen(size_t n_args, const mp_obj_t *args) {
+    mp_obj_socket_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    int backlog = SOMAXCONN < 128 ? SOMAXCONN : 128;
+    if (n_args > 1) {
+        backlog = (int)mp_obj_get_int(args[1]);
+        backlog = (backlog < 0) ? 0 : backlog;
+    }
+
     MP_THREAD_GIL_EXIT();
-    int r = listen(self->fd, MP_OBJ_SMALL_INT_VALUE(backlog_in));
+    int r = listen(self->fd, backlog);
     MP_THREAD_GIL_ENTER();
     RAISE_ERRNO(r, errno);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_listen_obj, socket_listen);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_listen_obj, 1, 2, socket_listen);
 
 STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
     mp_obj_socket_t *self = MP_OBJ_TO_PTR(self_in);

--- a/ports/zephyr/modusocket.c
+++ b/ports/zephyr/modusocket.c
@@ -185,11 +185,17 @@ STATIC mp_obj_t socket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_connect_obj, socket_connect);
 
-STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
-    socket_obj_t *socket = self_in;
+// method socket.listen([backlog])
+STATIC mp_obj_t socket_listen(size_t n_args, const mp_obj_t *args) {
+    socket_obj_t *socket = args[0];
     socket_check_closed(socket);
 
-    mp_int_t backlog = mp_obj_get_int(backlog_in);
+    mp_int_t backlog = 2;
+    if (n_args > 1) {
+        backlog = mp_obj_get_int(args[1]);
+        backlog = (backlog < 0) ? 0 : backlog;
+    }
+
     int res = zsock_listen(socket->ctx, backlog);
     RAISE_SOCK_ERRNO(res);
 

--- a/tests/multi_net/tcp_data.py
+++ b/tests/multi_net/tcp_data.py
@@ -10,7 +10,7 @@ def instance0():
     s = socket.socket()
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
-    s.listen(1)
+    s.listen()
     multitest.next()
     s2, _ = s.accept()
     print(s2.recv(16))


### PR DESCRIPTION
Socket listen with default argument of 128 for all ports BUT Unix where it defaults to 128 or SOMAXCONN whichever is less.

Did not apply this to cc3200 since it is not as straightforward.


from the docs
```rst
.. method:: socket.listen([backlog])

   Enable a server to accept connections. If *backlog* is specified, it must be at least 0
   (if it's lower, it will be set to 0); and specifies the number of unaccepted connections
   that the system will allow before refusing new connections. If not specified, a default
   reasonable value is chosen.
```