### PR TITLE
Function keyword syntax restriction

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -806,6 +806,9 @@ STATIC void push_result_rule(parser_t *parser, size_t src_line, uint8_t rule_id,
             // need to keep parenthesis for ()
         } else if (MP_PARSE_NODE_IS_STRUCT_KIND(pn, RULE_testlist_comp)) {
             // need to keep parenthesis for (a, b, ...)
+        } else if (MP_PARSE_NODE_IS_ID(pn) && parser->rule_stack[parser->rule_stack_top - 15].rule_id == RULE_arglist) {
+            // Keep parentheses around single IDs that are function arguments
+            // since they may be keyword arguments.
         } else {
             // parenthesis around a single expression, so it's just the expression
             return;

--- a/tests/basics/fun_kwargs_syntax.py
+++ b/tests/basics/fun_kwargs_syntax.py
@@ -9,6 +9,10 @@ def test_syntax(code):
 def f(a):
     return a
 
+# Should throw syntax errors.
 test_syntax("f((a)=2)")
 test_syntax("f(a()=2)")
 test_syntax("f(a or b=2)")
+test_syntax("f(2, (a)=3)")
+test_syntax("f((a) = 1, (b) = 5)")
+test_syntax("f((a, b) = 1)")

--- a/tests/basics/fun_kwargs_syntax.py
+++ b/tests/basics/fun_kwargs_syntax.py
@@ -1,0 +1,14 @@
+# Test function call keyword argument syntax
+
+def test_syntax(code):
+    try:
+        eval(code)
+    except SyntaxError:
+        print("SyntaxError in '{}'".format(code))
+
+def f(a):
+    return a
+
+test_syntax("f((a)=2)")
+test_syntax("f(a()=2)")
+test_syntax("f(a or b=2)")

--- a/utils/debug.h
+++ b/utils/debug.h
@@ -1,0 +1,17 @@
+/*
+ * debug.h
+ *
+ * Author: Rayane G. Chatrieux
+ * Date: Feb. 21, 2022
+ */
+#ifndef MICROPY_INCLUDED_PY_DEBUG_H
+#define MICROPY_INCLUDED_PY_DEBUG_H
+
+#include <stdio.h>
+
+#define DPRINTF(...) do { \
+        fprintf(stderr, "[%s: %d] %s(): ", __FILE__, __LINE__, __func__); \
+        fprintf(stderr, __VA_ARGS__); \
+    } while(0)
+
+#endif


### PR DESCRIPTION
Addresses the function keyword argument syntax restriction issued in Python 3.9. Code such as `f((a) = 2)` now raises a syntax error.